### PR TITLE
Add cookie-based auth (HttpOnly token)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,6 @@
-// const path = require('path');
-// const favicon = require('serve-favicon');
-// const cookieParser = require('cookie-parser');
-
 import express from 'express';
 import compression from 'compression';
+import cookieParser from 'cookie-parser';
 import { connect } from 'mongoose';
 import router from './router';
 
@@ -28,8 +25,7 @@ app.use(express.json());
 app.use(express.urlencoded({
   extended: true,
 }));
-
-// app.use(cookieParser());
+app.use(cookieParser());
 
 // Use dependency injection to start the router & pass in the express instance.
 router(app);

--- a/src/controllers/Collection.js
+++ b/src/controllers/Collection.js
@@ -26,17 +26,6 @@ const validateAddMemberToCollection = (request, response) => {
   return true;
 };
 
-const validateGetCollections = (request, response) => {
-  if (!request.query.user || !Types.ObjectId.isValid(request.query.user)) {
-    Responses.sendGenericErrorResponse(
-      response,
-      Strings.RESPONSE_MESSAGE.VALIDATION_FAILED,
-    );
-    return false;
-  }
-  // Valid data
-  return true;
-};
 
 const validateGetCollection = (request, response) => {
   if (!request.params.id || !Types.ObjectId.isValid(request.params.id)) {
@@ -101,14 +90,8 @@ export const getCollection = async (request, response) => {
 };
 
 export const getCollections = async (request, response) => {
-  // Validate input
-  const validData = validateGetCollections(request, response);
-  if (!validData) { return; }
-
   try {
-    const collections = await Collection.CollectionModel.findByMember(
-      request.query.user,
-    );
+    const collections = await Collection.CollectionModel.findByMember(request.userId);
     Responses.sendDataResponse(
       response,
       Strings.RESPONSE_MESSAGE.USER_COLLECTION_GET_SUCCESS,

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -5,7 +5,7 @@ import * as Strings from '../Strings';
 import * as Account from '../models/Account';
 
 export const validateToken = async (request, response, next) => {
-  const token = request.headers['x-access-token'];
+  const token = request.cookies?.token || request.headers['x-access-token'];
   if (!token) {
     Responses.sendBadTokenResponse(
       response,


### PR DESCRIPTION
## Summary

- **Enable `cookie-parser`** middleware in `app.js`
- **Set HttpOnly `token` cookie** on login, signup, and changePassword responses, with `secure: true` in production and a 90-day `maxAge`
- **Read token from cookie first** (with `x-access-token` header fallback) in `validateToken` middleware, `logout`, `changePassword`, `validateToken`, and `getUser` — backwards-compatible with existing header-auth clients
- **Revoke all sessions and issue a fresh token on `changePassword`** — previous tokens are invalidated immediately
- **Remove `validateGetCollections`** and the `user` query param requirement — `getCollections` now uses `req.userId` set by the upstream `validateToken` middleware, eliminating redundant re-validation

## Why cookies?

HttpOnly cookies are not accessible to JavaScript, which eliminates the XSS token-theft risk present with `sessionStorage`. The `sameSite: lax` policy retains CSRF protection.

## Test Plan

- [ ] `npm run build` passes with no errors
- [ ] `POST /api/login` responds with `Set-Cookie: token=...` header
- [ ] `GET /api/collections` succeeds with the cookie (no `x-access-token` header sent)
- [ ] `GET /api/collections` with an expired/missing cookie returns `bad_token`
- [ ] `POST /api/logout` clears the cookie
- [ ] `POST /api/change-password` invalidates old token and sets a new cookie
- [ ] Header-based auth (`x-access-token`) still works (backward-compat fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)