### PR TITLE
Add endpoint to log out other sessions

### DIFF
--- a/src/Strings.js
+++ b/src/Strings.js
@@ -48,6 +48,7 @@ export const RESPONSE_MESSAGE = {
   SIGNUP_SUCCESS: 'Account has been created successfully',
   CHANGE_PASSWORD_SUCCESS: 'Password has been changed successfully',
   LOGOUT_SUCCESS: 'Successfully logged out',
+  LOGOUT_OTHER_SESSIONS_SUCCESS: 'Successfully logged out of other sessions',
   TOKEN_AUTH_SUCCESS: 'Token authenticated successfully',
   FORGOT_PASSWORD_RESPONSE: 'Check your email for further instructions',
 

--- a/src/controllers/Account.js
+++ b/src/controllers/Account.js
@@ -253,6 +253,35 @@ export const logout = async (request, response) => {
   );
 };
 
+export const logoutOtherSessions = async (request, response) => {
+  const account = await Account.AccountModel.findOne({ _id: request.userId }).exec();
+
+  if (!account) {
+    Responses.sendGenericErrorResponse(
+      response,
+      Strings.RESPONSE_MESSAGE.NOT_FOUND,
+    );
+    return;
+  }
+
+  const previousTokenCount = account.tokens.length;
+  const newToken = createToken(account._id);
+  account.tokens = [newToken];
+
+  await account.save();
+
+  response.cookie('token', newToken, cookieOptions);
+
+  Responses.sendDataResponse(
+    response,
+    Strings.RESPONSE_MESSAGE.LOGOUT_OTHER_SESSIONS_SUCCESS,
+    {
+      removed: Math.max(previousTokenCount - 1, 0),
+      tokenCount: 1,
+    },
+  );
+};
+
 export const changePassword = async (request, response) => {
   const validParams = validateChangePassword(request, response);
   if (!validParams) { return; }

--- a/src/router.js
+++ b/src/router.js
@@ -12,6 +12,7 @@ const router = (app) => {
 
   // Authentication functions
   app.post('/logout', middleware.validateToken, Account.logout);
+  app.post('/logoutOtherSessions', middleware.validateToken, Account.logoutOtherSessions);
   app.post('/login', Account.login);
   app.post('/signup', Account.signup);
   app.post('/forgotPassword', Account.forgotPassword);


### PR DESCRIPTION
## Summary
- Add authenticated `POST /logoutOtherSessions` endpoint.
- Revoke all other sessions while rotating the current token.
- Return `removed` count and `tokenCount` in the response payload.

## Testing
- `npm run build`
